### PR TITLE
chrome在跨域的情况下不支持download属性，于是用xhr做了个work around

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -145,7 +145,29 @@ onMsg.addListener(
       } else {
         filename = $.trim(filename) + '.' + request.format;
       }
+      
+      // remain the old download code for failback
       $('#dlink').attr('download', filename).attr('title', filename).attr('href', url);
+	  
+      // chrome doesn't support download attribute for cross-site request, 
+      // so use the code below to work around
+      if (url !== window.currentMusicUrl) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', url, true);
+        xhr.responseType = 'blob';
+
+        xhr.onload = function(e) {
+          var res = xhr.response;
+          var blob = new Blob([res], {type:"audio/mpeg"});
+
+          window.URL.revokeObjectURL(window.downloadUrl);
+          window.currentMusicUrl = url;
+          window.downloadUrl = window.URL.createObjectURL(blob);
+          document.getElementById('dlink').href = downloadUrl;
+        };
+        xhr.send();
+      }
+	  
       (function(deg){
         var degnow = 0;
         var ro = function(){


### PR DESCRIPTION
之前那个Chrome不支持download属性的问题……现在chrome开发团队决定，对于跨域请求的情况，出于安全的原因不支持download属性了。
于是我参照别人的一个work around，通过xhr来下载音乐文件，绕过了download属性的限制。
因为这个方法得等到把歌曲文件下载完才可用，所以同时保留原有的方法作为fallback。
亲测在网易云音乐和豆瓣fm、虾米电台下可用。
不过尚未在其他平台测试过。
